### PR TITLE
Centralize name-logic with fallback to filename

### DIFF
--- a/Spectabis-WPF/Views/AddGame.xaml.cs
+++ b/Spectabis-WPF/Views/AddGame.xaml.cs
@@ -66,25 +66,16 @@ namespace Spectabis_WPF.Views
             }
             if (ISODialog.ShowDialog().Value == true)
             {
-                var serial = GetSerial.GetSerialNumber(ISODialog.FileName);
-
                 if(Properties.Settings.Default.titleAsFile)
                 {
                     title = Path.GetFileNameWithoutExtension(ISODialog.FileName);
                 }
                 else
                 {
-                    title = GetGameName.GetName(serial);
+                    title = GetGameName.GetName(ISODialog.FileName);
                 }
-                
+
                 var file = ISODialog.FileName;
-
-                //If title was not extracted, set it from file
-                if(title == "UNKNOWN")
-                {
-                    title = Path.GetFileNameWithoutExtension(file);
-                }
-
                 title = GameProfile.Create(null, file, title);
 
                 //Change initial button and text

--- a/Spectabis-WPF/Views/GameDiscovery.xaml.cs
+++ b/Spectabis-WPF/Views/GameDiscovery.xaml.cs
@@ -101,10 +101,9 @@ namespace Spectabis_WPF.Views
         {
             foreach(string game in gamesToAdd)
             {
-                var profile = GetSerial.GetSerialNumber(game);
-                profile = GetGameName.GetName(profile);
-                GameProfile.Create(null,game,profile);
+                GameProfile.Create(null, game, GetGameName.GetName(game));
             }
+
             Console.WriteLine("Game profiles created!");
             Back();
         }

--- a/Spectabis-WPF/Views/Library.xaml.cs
+++ b/Spectabis-WPF/Views/Library.xaml.cs
@@ -841,11 +841,9 @@ namespace Spectabis_WPF.Views
         //Push when a new game in directory is detected
         private void PushDirectoryDialog(string game)
         {
-            string serial = GetSerial.GetSerialNumber(game);
-
             TextBlock text = new TextBlock();
             text.FontFamily = new FontFamily("Roboto Light");
-            text.Text = $"Would you like to add \"{GetGameName.GetName(serial)}\" ?";
+            text.Text = $"Would you like to add \"{GetGameName.GetName(game)}\" ?";
             text.TextWrapping = TextWrapping.Wrap;
             text.VerticalAlignment = VerticalAlignment.Center;
             text.Margin = new Thickness(0, 0, 10, 0);
@@ -888,27 +886,13 @@ namespace Spectabis_WPF.Views
             {
                 Console.WriteLine("Adding " + game);
 
-                //If file supports extraction of serial number, then do just that
-                if (SupportedGames.ScrappingFiles.Any(s => game.EndsWith(s)))
+                if (Properties.Settings.Default.titleAsFile)
                 {
-                    //If file supports scrapping, then do that
-                    string serial = GetSerial.GetSerialNumber(game);
-                    string title = GetGameName.GetName(serial);
-
-                    if (Properties.Settings.Default.titleAsFile)
-                    {
-                        AddGame(null, game, Path.GetFileNameWithoutExtension(game));
-                    }
-                    else
-                    {
-                        AddGame(null, game, title);
-                    }
+                    AddGame(null, game, Path.GetFileNameWithoutExtension(game));
                 }
                 else
                 {
-                    //Add game and use file name as game name
-                    string title = Path.GetFileNameWithoutExtension(game);
-                    AddGame(null, game, title);
+                    AddGame(null, game, GetGameName.GetName(game));
                 }
             }
 
@@ -987,16 +971,13 @@ namespace Spectabis_WPF.Views
                     //If file supports name scrapping
                     if (SupportedGames.ScrappingFiles.Any(s => file.EndsWith(s)))
                     {
-                        string SerialNumber = GetSerial.GetSerialNumber(file);
-                        string GameName = GetGameName.GetName(SerialNumber);
-
                         if(Properties.Settings.Default.titleAsFile)
                         {
                             AddGame(null, file, Path.GetFileNameWithoutExtension(file));
                         }
                         else
                         {
-                            AddGame(null, file, GameName);
+                            AddGame(null, file, GetGameName.GetName(file));
                         }
                     }
                     else


### PR DESCRIPTION
GetName() now does all the required work to get a game's name and always falls back to the name of the file, which provides more information to the user than 'UNKNOWN'. Fixes #12