### PR TITLE
Changed stuff around the global config emuDir

### DIFF
--- a/Spectabis-WPF/Domain/GameProfile.cs
+++ b/Spectabis-WPF/Domain/GameProfile.cs
@@ -6,7 +6,7 @@ namespace Spectabis_WPF.Domain
     class GameProfile
     {
         private static string BaseDirectory = AppDomain.CurrentDomain.BaseDirectory;
-        private static string emuDir = Properties.Settings.Default.emuDir;
+        private static string emuDir = Path.GetDirectoryName(Properties.Settings.Default.emuDir);
         private static int index = 0;
         private static string GlobalController = BaseDirectory + @"resources\configs\#global_controller\LilyPad.ini";
 

--- a/Spectabis-WPF/Domain/GameProfile.cs
+++ b/Spectabis-WPF/Domain/GameProfile.cs
@@ -6,7 +6,7 @@ namespace Spectabis_WPF.Domain
     class GameProfile
     {
         private static string BaseDirectory = AppDomain.CurrentDomain.BaseDirectory;
-        private static string emuDir = Path.GetDirectoryName(Properties.Settings.Default.emuDir);
+        public static string emuDir { get => Path.GetDirectoryName(Properties.Settings.Default.emuDir); }
         private static int index = 0;
         private static string GlobalController = BaseDirectory + @"resources\configs\#global_controller\LilyPad.ini";
 

--- a/Spectabis-WPF/Domain/GameProfile.cs
+++ b/Spectabis-WPF/Domain/GameProfile.cs
@@ -6,7 +6,7 @@ namespace Spectabis_WPF.Domain
     class GameProfile
     {
         private static string BaseDirectory = AppDomain.CurrentDomain.BaseDirectory;
-        public static string emuDir { get => Path.GetDirectoryName(Properties.Settings.Default.emuDir); }
+        public static string emuDir { get { return Path.GetDirectoryName(Properties.Settings.Default.emuDir); } }
         private static int index = 0;
         private static string GlobalController = BaseDirectory + @"resources\configs\#global_controller\LilyPad.ini";
 

--- a/Spectabis-WPF/Domain/GetGameName.cs
+++ b/Spectabis-WPF/Domain/GetGameName.cs
@@ -6,7 +6,7 @@ namespace Spectabis_WPF.Domain
 {
     class GetGameName
     {
-        public static string emuDir { get => Path.GetDirectoryName(Properties.Settings.Default.emuDir); }
+        public static string emuDir { get { return Path.GetDirectoryName(Properties.Settings.Default.emuDir); } }
 
         //Returns a game name, using PCSX2 database file
         public static string GetName(string _path)

--- a/Spectabis-WPF/Domain/GetGameName.cs
+++ b/Spectabis-WPF/Domain/GetGameName.cs
@@ -6,7 +6,7 @@ namespace Spectabis_WPF.Domain
 {
     class GetGameName
     {
-        private static string emuDir = Properties.Settings.Default.emuDir;
+        private static string emuDir = Path.GetDirectoryName(Properties.Settings.Default.emuDir);
 
         //Returns a game name, using PCSX2 database file
         public static string GetName(string _path)

--- a/Spectabis-WPF/Domain/GetGameName.cs
+++ b/Spectabis-WPF/Domain/GetGameName.cs
@@ -6,7 +6,7 @@ namespace Spectabis_WPF.Domain
 {
     class GetGameName
     {
-        private static string emuDir = Path.GetDirectoryName(Properties.Settings.Default.emuDir);
+        public static string emuDir { get => Path.GetDirectoryName(Properties.Settings.Default.emuDir); }
 
         //Returns a game name, using PCSX2 database file
         public static string GetName(string _path)

--- a/Spectabis-WPF/Domain/LaunchPCSX2.cs
+++ b/Spectabis-WPF/Domain/LaunchPCSX2.cs
@@ -34,7 +34,7 @@ namespace Spectabis_WPF.Domain
             if (_fullboot == "1") { _launchargs = _launchargs + "--fullboot "; }
             if (_nohacks == "1") { _launchargs = _launchargs + "--nohacks "; }
 
-            Console.WriteLine($"{_launchargs} {_isoDir} --cfgpath {gamePath}");
+            Console.WriteLine($"{_launchargs} {_isoDir} --cfgpath={gamePath}");
 
             //Paths in PCSX2 command arguments have to be in quotes...
             const string quote = "\"";
@@ -42,10 +42,10 @@ namespace Spectabis_WPF.Domain
             Process PCSX = new Process();
 
             //PCSX2 Process
-            if(File.Exists(Properties.Settings.Default.emuDir + @"\pcsx2.exe"))
+            if(File.Exists(Properties.Settings.Default.emuDir))
             {
-                PCSX.StartInfo.FileName = Properties.Settings.Default.emuDir + @"\pcsx2.exe";
-                PCSX.StartInfo.Arguments = $"{_launchargs} {quote}{_isoDir}{quote} --cfgpath {quote}{gamePath}{quote}";
+                PCSX.StartInfo.FileName = Properties.Settings.Default.emuDir;
+                PCSX.StartInfo.Arguments = $"{_launchargs} {quote}{_isoDir}{quote} --cfgpath={quote}{gamePath}{quote}";
 
                 PCSX.Start();
 
@@ -56,7 +56,7 @@ namespace Spectabis_WPF.Domain
             }
             else
             {
-                Console.WriteLine(Properties.Settings.Default.emuDir + @"\pcsx2.exe" + " does not exist!");
+                Console.WriteLine(Properties.Settings.Default.emuDir + " does not exist!");
             }
             
         }

--- a/Spectabis-WPF/Views/FirstTimeSetup.xaml.cs
+++ b/Spectabis-WPF/Views/FirstTimeSetup.xaml.cs
@@ -24,7 +24,7 @@ namespace Spectabis_WPF.Views
             if(StepCounter == 0)
             {
                 Ookii.Dialogs.Wpf.VistaOpenFileDialog emuBrowser = new Ookii.Dialogs.Wpf.VistaOpenFileDialog();
-                emuBrowser.Filter = "PCSX2 Executable | PCSX2.exe|Executable|*.exe";
+                emuBrowser.Filter = "PCSX2 Executable | *.exe|Executable|*.exe";
 
                 //Show dialog
                 var browserResult = emuBrowser.ShowDialog();
@@ -32,15 +32,14 @@ namespace Spectabis_WPF.Views
                 {
                     string _result = emuBrowser.FileName;
 
-                    //If filename contains ".exe", just in case
-                    if (_result.Contains(".exe") == false)
+                    if (_result.ToLower().Contains("pcsx2") == false || _result.ToLower().EndsWith(".exe") == false)
                     {
                         MessageBox.Show("Invalid file.");
                         return;
                     }
 
-                    //Save selected path, remove pcsx2.exe from string
-                    Properties.Settings.Default.emuDir = _result.Replace("pcsx2.exe", string.Empty);
+                    //Save selected path, *don't* remove pcsx2.exe from string
+                    Properties.Settings.Default.emuDir = _result;
                     Properties.Settings.Default.Save();
 
                     //Increment Step count

--- a/Spectabis-WPF/Views/Library.xaml.cs
+++ b/Spectabis-WPF/Views/Library.xaml.cs
@@ -27,7 +27,7 @@ namespace Spectabis_WPF.Views
     {
 
         //Spectabis Variables
-        public static string emuDir { get => Properties.Settings.Default.emuDir; }
+        public static string emuDir { get { return Properties.Settings.Default.emuDir; } }
         private string GameConfigs;
         private string BaseDirectory = AppDomain.CurrentDomain.BaseDirectory;
 

--- a/Spectabis-WPF/Views/Library.xaml.cs
+++ b/Spectabis-WPF/Views/Library.xaml.cs
@@ -27,7 +27,7 @@ namespace Spectabis_WPF.Views
     {
 
         //Spectabis Variables
-        public static string emuDir = Properties.Settings.Default.emuDir;
+        public static string emuDir { get => Properties.Settings.Default.emuDir; }
         private string GameConfigs;
         private string BaseDirectory = AppDomain.CurrentDomain.BaseDirectory;
 

--- a/Spectabis-WPF/Views/Library.xaml.cs
+++ b/Spectabis-WPF/Views/Library.xaml.cs
@@ -176,7 +176,7 @@ namespace Spectabis_WPF.Views
             var _gameIni = new IniFile(_cfgDir + @"\spectabis.ini");
             var _isoDir = _gameIni.Read("isoDirectory", "Spectabis");
 
-            if (File.Exists(emuDir + @"\pcsx2.exe") == false)
+            if (File.Exists(emuDir) == false)
             {
                 PushSnackbar("PCSX2 installation corrupt");
             }
@@ -218,7 +218,7 @@ namespace Spectabis_WPF.Views
                         if (_fullboot == "1") { _launchargs = _launchargs + "--fullboot "; }
                         if (_nohacks == "1") { _launchargs = _launchargs + "--nohacks "; }
 
-                        Console.WriteLine($"{_launchargs} {_isoDir} --cfgpath {_cfgDir}");
+                        Console.WriteLine($"{_launchargs} {_isoDir} --cfgpath={_cfgDir}");
 
                         //Copy global controller settings
                         Console.WriteLine($"CopyGlobalProfile({clickedBoxArt.Tag.ToString()})");
@@ -228,8 +228,8 @@ namespace Spectabis_WPF.Views
                         const string quote = "\"";
 
                         //PCSX2 Process
-                        PCSX.StartInfo.FileName = emuDir + @"\pcsx2.exe";
-                        PCSX.StartInfo.Arguments = $"{_launchargs} {quote}{_isoDir}{quote} --cfgpath {quote}{_cfgDir}{quote}";
+                        PCSX.StartInfo.FileName = emuDir;
+                        PCSX.StartInfo.Arguments = $"{_launchargs} {quote}{_isoDir}{quote} --cfgpath={quote}{_cfgDir}{quote}";
 
                         PCSX.EnableRaisingEvents = true;
                         PCSX.Exited += new EventHandler(PCSX_Exited);
@@ -333,7 +333,7 @@ namespace Spectabis_WPF.Views
 
             //Start PCSX2 only with --cfgpath
             string _cfgDir = GameConfigs + @"/" + clickedBoxArt.Tag;
-            Process.Start(emuDir + @"\pcsx2.exe", " --cfgpath \"" + _cfgDir + "\"");
+            Process.Start(emuDir, " --cfgpath=\"" + _cfgDir + "\"");
 
         }
 

--- a/Spectabis-WPF/Views/MainWindow.xaml.cs
+++ b/Spectabis-WPF/Views/MainWindow.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -584,8 +585,9 @@ namespace Spectabis_WPF.Views
 
             if(File.Exists(GSdxfx) == false)
             {
-                File.Copy(Properties.Settings.Default.emuDir + @"\shaders\GSdx.fx", GSdxfx);
-                File.Copy(Properties.Settings.Default.emuDir + @"\shaders\GSdx_FX_Settings.ini", GSdxfxini);
+                var dir = Path.GetDirectoryName(Properties.Settings.Default.emuDir);
+                File.Copy(dir + @"\shaders\GSdx.fx", GSdxfx);
+                File.Copy(dir + @"\shaders\GSdx_FX_Settings.ini", GSdxfxini);
             }
         }
 
@@ -766,13 +768,12 @@ namespace Spectabis_WPF.Views
         {
             List<string> chars = new List<string>();
             //Remove unsupported characters
-            TitleEditBox.Text = TitleEditBox.Text.Replace(@"/", string.Empty);
-            TitleEditBox.Text = TitleEditBox.Text.Replace(@"\", string.Empty);
-            TitleEditBox.Text = TitleEditBox.Text.Replace(@":", string.Empty);
-            TitleEditBox.Text = TitleEditBox.Text.Replace(@"|", string.Empty);
-            TitleEditBox.Text = TitleEditBox.Text.Replace(@"*", string.Empty);
-            TitleEditBox.Text = TitleEditBox.Text.Replace(@"<", string.Empty);
-            TitleEditBox.Text = TitleEditBox.Text.Replace(@">", string.Empty);
+            {
+                var tempText = TitleEditBox.Text;
+                foreach (var illegal in new[] { "/", "\\", ":", "|", "*", "<", ">" })
+                    tempText = tempText.Replace(illegal, string.Empty);
+                TitleEditBox.Text = tempText;
+            }
 
             Console.WriteLine(e.Key.ToString());
 

--- a/Spectabis-WPF/Views/Settings.xaml.cs
+++ b/Spectabis-WPF/Views/Settings.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -111,7 +112,7 @@ namespace Spectabis_WPF.Views
         {
             if (Directory.Exists(emudir_text.Text))
             {
-                if (File.Exists(emudir_text.Text + @"/pcsx2.exe"))
+                if (File.Exists(emudir_text.Text))
                 {
                     Properties.Settings.Default.emuDir = emudir_text.Text;
                     Properties.Settings.Default.Save();
@@ -226,8 +227,9 @@ namespace Spectabis_WPF.Views
             //If OK was clicked...
             if(BrowserResult == true)
             {
-                if (File.Exists(BrowserDialog.SelectedPath + @"/pcsx2.exe") == false)
-                {
+                var filesInFolder = Directory.GetFiles(BrowserDialog.SelectedPath);
+
+                if (filesInFolder.Any(p=>p.Contains("pcsx2") && p.EndsWith(".exe")) == false){
                     //If directory isn't PCSX2's, fall back to beginning
                     PushSnackbar("Invalid Emulator Directory");
                     goto ShowDialog;


### PR DESCRIPTION
instead of removing the executable from the path. Instead i choose to preserve it, why?
Because my executable was called "pcsx2-r5350.exe" yet Specabis was unable to pick it up. So the code now preserves the full path to the .exe chosen by the user and in the usages instead uses Path.GetDirectoryName() in cases which you'd need the directory. I'm tempted to change the configuration variable name, but since it's a serialized property it'll probably cause an avalanche of problems across clients.

I also had issues with the command lines of "--cfgpath " pcsx2 pops up with an error that tells me that the command-line is "--cfgpath=" which i corrected, please verify that this is not an old version or something.

I'm still having issues with the interop calls for the configuration system. Was this functional prior to my changes?